### PR TITLE
Update example in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ PhotoCollection photos = flickr.PhotosSearch(options);
 
 foreach(Photo photo in photos) 
 {
-  Console.WriteLine("Photo {0} has title {1}", photo.PhotoID, photo.Title);
+  Console.WriteLine("Photo {0} has title {1}", photo.PhotoId, photo.Title);
 }
 ~~~
 


### PR DESCRIPTION
I am fixing a typo in the example in the ReadMe page, instead of photo.PhotoID it should be photo.PhotoId