### PR TITLE
Extend PhotoSearchOptions with the support for Styles.

### DIFF
--- a/FlickrNet/Enums.cs
+++ b/FlickrNet/Enums.cs
@@ -306,5 +306,30 @@ namespace FlickrNet
         Everybody = 3
     }
 
+    /// <summary>
+    /// An enumeration of photo styles.
+    /// </summary>
+    [Serializable]
+    public enum Style
+    {
+        /// <summary>
+        /// Black and white.
+        /// </summary>
+        BlackAndWhite = 0,
 
+        /// <summary>
+        /// Shallow depth of field.
+        /// </summary>
+        DepthOfField = 1,
+
+        /// <summary>
+        /// Minimalist.
+        /// </summary>
+        Minimalism = 2,
+
+        /// <summary>
+        /// Patterns.
+        /// </summary>
+        Pattern = 3
+    }
 }

--- a/FlickrNet/PhotoSearchOptions.cs
+++ b/FlickrNet/PhotoSearchOptions.cs
@@ -365,6 +365,11 @@ namespace FlickrNet
         public ICollection<string> ColorCodes { get; set; }
 
         /// <summary>
+        /// A collection of styles the search results will be filtered against.
+        /// </summary>
+        public ICollection<Style> Styles { get; set; }
+
+        /// <summary>
         /// Calculates the Uri for a Flash slideshow for the given search options.
         /// </summary>
         /// <returns></returns>
@@ -452,7 +457,8 @@ namespace FlickrNet
             if (FoursquareVenueID != null) parameters.Add("foursquare_venueid", FoursquareVenueID);
             if (FoursquareWoeID != null) parameters.Add("foursquare_woeid", FoursquareWoeID);
             if (GroupPathAlias != null) parameters.Add("group_path_alias", GroupPathAlias);
-            if( ColorCodes != null && ColorCodes.Count != 0 ) parameters.Add("color_codes", ColorCodeString);
+            if (ColorCodes != null && ColorCodes.Count != 0 ) parameters.Add("color_codes", ColorCodeString);
+            if (Styles != null && Styles.Count != 0) parameters.Add("styles", UtilityMethods.StylesToString(Styles));
         }
 
     }

--- a/FlickrNet/UtilityMethods.cs
+++ b/FlickrNet/UtilityMethods.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Xml.Serialization;
 using System.Xml;
 using System.Collections.Generic;
+using System.Linq;
 #if SILVERLIGHT
 using System.Linq;
 #endif
@@ -669,6 +670,19 @@ namespace FlickrNet
             }
 
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Converts a collection of <see cref="Style"/> values to a string literal containing the 
+        /// lowercase string representations of each distinct style once, separated by commas.
+        /// </summary>
+        /// <param name="styles">Set of styles.</param>
+        /// <returns>Concatenated styles.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="styles"/> is null.</exception>
+        /// <exception cref="OutOfMemoryException">Out of memory.</exception>
+        public static string StylesToString(ICollection<Style> styles)
+        {
+            return string.Join(",", styles.Distinct().Select(s => s.ToString().ToLower()));
         }
     }
 

--- a/FlickrNetTest/PhotoSearchOptionsTests.cs
+++ b/FlickrNetTest/PhotoSearchOptionsTests.cs
@@ -1,6 +1,7 @@
 ﻿
 using NUnit.Framework;
 using FlickrNet;
+using System.Collections.Generic;
 
 namespace FlickrNetTest
 {
@@ -36,6 +37,42 @@ namespace FlickrNetTest
             {
                 Assert.IsTrue(photo.Views.HasValue);
             }
+        }
+
+        [Test]
+        public void StylesNotAddedToParameters_WhenItIsNotSet()
+        {
+            var o = new PhotoSearchOptions();
+            var parameters = new Dictionary<string, string>();
+
+            o.AddToDictionary(parameters);
+
+            Assert.IsFalse(parameters.ContainsKey("styles"));
+        }
+
+        [Test]
+        public void StylesNotAddedToParameters_WhenItIsEmpty()
+        {
+            var o = new PhotoSearchOptions { Styles = new List<Style>() };
+            var parameters = new Dictionary<string, string>();
+
+            o.AddToDictionary(parameters);
+
+            Assert.IsFalse(parameters.ContainsKey("styles"));
+        }
+
+        [TestCase(Style.BlackAndWhite)]
+        [TestCase(Style.BlackAndWhite, Style.DepthOfField)]
+        [TestCase(Style.BlackAndWhite, Style.DepthOfField, Style.Minimalism)]
+        [TestCase(Style.BlackAndWhite, Style.DepthOfField, Style.Minimalism, Style.Pattern)]
+        public void StylesAddedToParameters_WhenItIsNotNullOrEmpty(params Style[] styles)
+        {
+            var o = new PhotoSearchOptions { Styles = new List<Style>(styles) };
+            var parameters = new Dictionary<string, string>();
+
+            o.AddToDictionary(parameters);
+
+            Assert.IsTrue(parameters.ContainsKey("styles"));
         }
     }
 }

--- a/FlickrNetTest/PhotosSearchTests.cs
+++ b/FlickrNetTest/PhotosSearchTests.cs
@@ -331,6 +331,26 @@ namespace FlickrNetTest
             }
         }
 
+        [TestCase(Style.BlackAndWhite)]
+        [TestCase(Style.DepthOfField)]
+        [TestCase(Style.Minimalism)]
+        [TestCase(Style.Pattern)]
+        public void PhotoSearchByStyles(Style style)
+        {
+            var o = new PhotoSearchOptions
+            {
+                Text = "nature",
+                Page = 1,
+                PerPage = 10,
+                Styles = new[] { style }
+            };
+
+            var photos = Instance.PhotosSearch(o);
+
+            Assert.IsNotNull(photos);
+            Assert.IsNotEmpty(photos);
+        }
+
         [Test]
         public void PhotosSearchIsCommons()
         {

--- a/FlickrNetTest/UtilityMethodsTests.cs
+++ b/FlickrNetTest/UtilityMethodsTests.cs
@@ -461,5 +461,41 @@ namespace FlickrNetTest
             Assert.AreEqual(string.Empty, b);
         }
 
+        [Test]
+        public void StylesToString_ParameterIsNull_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => UtilityMethods.StylesToString(null));
+        }
+
+        [Test]
+        public void StyleToString_ParameterIsEmpty_ReturnsEmptyString()
+        {
+            Assert.AreEqual(UtilityMethods.StylesToString(new List<Style>()), string.Empty);
+        }
+
+        [TestCase(Style.BlackAndWhite, "blackandwhite")]
+        [TestCase(Style.DepthOfField, "depthoffield")]
+        [TestCase(Style.Minimalism, "minimalism")]
+        [TestCase(Style.Pattern, "pattern")]
+        public void StylesToString_ConvertsSingletonCollectionIntoString(Style style, string excepted)
+        {
+            Assert.AreEqual(UtilityMethods.StylesToString(new[] { style }), excepted);
+        }
+
+        [TestCase("blackandwhite,depthoffield", Style.BlackAndWhite, Style.DepthOfField)]
+        [TestCase("depthoffield,minimalism,pattern", Style.DepthOfField, Style.Minimalism, Style.Pattern)]
+        [TestCase("minimalism,pattern,depthoffield,blackandwhite", Style.Minimalism, Style.Pattern, Style.DepthOfField, Style.BlackAndWhite)]
+        public void StylesToString_SeparatesValuesByComma(string expected, params Style[] styles)
+        {
+            Assert.AreEqual(UtilityMethods.StylesToString(styles), expected);
+        }
+
+        [TestCase("blackandwhite", Style.BlackAndWhite, Style.BlackAndWhite)]
+        [TestCase("blackandwhite,minimalism", Style.BlackAndWhite, Style.BlackAndWhite, Style.Minimalism, Style.Minimalism)]
+        [TestCase("blackandwhite,pattern,minimalism", Style.BlackAndWhite, Style.BlackAndWhite, Style.Pattern, Style.Minimalism, Style.Minimalism)]
+        public void StylesToString_FiltersOutRecurrences(string expected, params Style[] styles)
+        {
+            Assert.AreEqual(UtilityMethods.StylesToString(styles), expected);
+        }
     }
 }


### PR DESCRIPTION
Along with color codes,  Flickr's web search interface supports using photo styles to filter search results. The available styles are: Black and white, Shallow depth of field, Minimalist and Patterns. Multiple styles can be used at the same time.